### PR TITLE
Repair dm6_50.txt

### DIFF
--- a/epic/scripts/effective_sizes/dm6_50.txt
+++ b/epic/scripts/effective_sizes/dm6_50.txt
@@ -1,4 +1,4 @@
 File analyzed:  trimmed_fasta/dm6.trimmed.fa
 Genome length:  137567484
-Number unique 50-mers:  19088831
-Effective genome size:  0.138759759537
+Number unique 50-mers:  120949316
+Effective genome size:  0.8791998841819336


### PR DESCRIPTION
dm6_50.txt effective size estimate is broken for unknown reasons. This replaces the file with the actual output from the genome.snakefile run.